### PR TITLE
CI/CD: Link shared locally instead of "npm i"

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,10 +16,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: npm install, npm test
+      - name: npm install, npm te
         run: |
-          cd server
-          npm install
+          cd shared
+          npm i
+          npm run build
+          cd dist
+          npm link
+          cd ../../server
+          npm link engraved-shared
+          npm i
           npm test
         env:
           CI: true

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3197,9 +3197,7 @@
       }
     },
     "engraved-shared": {
-      "version": "0.0.111",
-      "resolved": "https://registry.npmjs.org/engraved-shared/-/engraved-shared-0.0.111.tgz",
-      "integrity": "sha512-bEiQSS8fsHtGYAhMwdp43K3lq9Eu0dSLzAg3m4BppWrBezO7QPmDKmpaplDqUjtSMAwYjcCCrI7bnJ0EBdeO0w=="
+      "version": "0.0.123"
     },
     "enhanced-resolve": {
       "version": "3.4.1",
@@ -3936,7 +3934,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3954,11 +3953,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3971,15 +3972,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4082,7 +4086,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4092,6 +4097,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4104,17 +4110,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4131,6 +4140,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4203,7 +4213,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4213,6 +4224,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4288,7 +4300,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4318,6 +4331,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4335,6 +4349,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4373,11 +4388,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "codemirror": "^5.49.0",
     "date-fns": "^2.3.0",
-    "engraved-shared": "0.0.111",
+    "engraved-shared": "0.0.123",
     "markdown-it": "^10.0.0",
     "markdown-it-anchor": "^5.2.4",
     "markdown-it-table-of-contents": "^0.4.4",
@@ -24,8 +24,7 @@
     "build": "react-scripts-ts build",
     "build-ts": "react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom",
-    "eject": "react-scripts-ts eject",
-    "analyze": "npm webpack-bundle-analyzer 'build/static/js/*.js'"
+    "eject": "react-scripts-ts eject"
   },
   "devDependencies": {
     "@types/codemirror": "^0.0.77",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,11 @@
   "version": "0.0.2",
   "dependencies": {},
   "scripts": {
-    "start": "npm run server:prod",
-    "server:prod": "cd server && npm run prod",
-    "server:build:prod": "cd server && npm install && npm install --only=dev --no-shrinkwrap && npm run build",
-    "client:build:prod": "cd client && npm install && npm install --only=dev --no-shrinkwrap && npm run build && copyfiles -u 1 build/**/*.* ../server/dist/client",
-    "heroku-postbuild": "npm run server:build:prod && npm run client:build:prod",
-    "precommit": "pretty-quick --staged"
+    "start": "npm run shared:link && cd server && npm run prod",
+    "heroku-postbuild": "npm run shared:link && npm run server:build:prod && npm run client:build:prod",
+    "server:build:prod": "cd server && npm link engraved-shared && npm install && npm install --only=dev --no-shrinkwrap && npm run build",
+    "client:build:prod": "cd client && npm link engraved-shared && npm install && npm install --only=dev --no-shrinkwrap && npm run build && copyfiles -u 1 build/**/*.* ../server/dist/client",
+    "shared:link": "cd shared && npm install && npm install --only=dev --no-shrinkwrap && npm run build && cd dist && npm link && npm install && cd ../../"
   },
   "devDependencies": {
     "copyfiles": "^2.1.1",
@@ -21,5 +20,10 @@
   },
   "engines": {
     "node": "8.11.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -536,12 +536,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "@types/jasmine": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.4.2.tgz",
-      "integrity": "sha512-SaSSGOzwUnBEn64c+HTyVTJhRf8F1CXZLnxYx2ww3UrgGBmEEw38RSux2l3fYiT9brVLP67DU5omWA6V9OHI5Q==",
-      "dev": true
-    },
     "@types/jest": {
       "version": "24.0.18",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.18.tgz",
@@ -1984,9 +1978,7 @@
       }
     },
     "engraved-shared": {
-      "version": "0.0.111",
-      "resolved": "https://registry.npmjs.org/engraved-shared/-/engraved-shared-0.0.111.tgz",
-      "integrity": "sha512-bEiQSS8fsHtGYAhMwdp43K3lq9Eu0dSLzAg3m4BppWrBezO7QPmDKmpaplDqUjtSMAwYjcCCrI7bnJ0EBdeO0w=="
+      "version": "0.0.123"
     },
     "error-ex": {
       "version": "1.3.2",
@@ -2579,7 +2571,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2600,12 +2593,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2620,17 +2615,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2747,7 +2745,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2759,6 +2758,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2773,6 +2773,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2780,12 +2781,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2804,6 +2807,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2884,7 +2888,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2896,6 +2901,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2981,7 +2987,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3017,6 +3024,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3036,6 +3044,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3079,12 +3088,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
-    "engraved-shared": "0.0.111",
+    "engraved-shared": "0.0.123",
     "express": "^4.17.1",
     "mongodb": "^3.3.2",
     "passport": "^0.4.0",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "engraved-shared",
-  "version": "0.0.109",
+  "version": "0.0.123",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,15 +1,13 @@
 {
   "name": "engraved-shared",
-  "version": "0.0.111",
+  "version": "0.0.123",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
     "copy-package-json": "copyfiles package.json dist",
     "dev-shared": "npm run copy-package-json && tsc -w",
     "lint": "tslint --project tsconfig.json",
-    "build": "tsc && npm run copy-package-json",
-    "validate": "npm run build && cd dist && npm link && cd ..\\..\\server && npm link engraved-shared && npm run build && cd ..\\client && npm link engraved-shared && npm run build-ts",
-    "publish-to-npm": "npm run build && cd dist && npm publish"
+    "build": "tsc && npm run copy-package-json"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Why?
- Makes it easier to develop and publish (no more
  publishing to npm any more
- Public npm package ain't required anyway, I only need
  it for myself

Additional notes:
Do not quite know, why I need to "npm run shared:link" in package.json
in root folder. But at least it works now.