### PR TITLE
#96: Use "file:" in package.json instead of link

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,9 +23,7 @@ jobs:
           npm test
           npm run build
           cd dist
-          npm link
           cd ../../server
-          npm link engraved-shared
           npm i
           npm test
         env:

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3197,7 +3197,7 @@
       }
     },
     "engraved-shared": {
-      "version": "0.0.123"
+      "version": "file:../shared/dist"
     },
     "enhanced-resolve": {
       "version": "3.4.1",
@@ -3934,8 +3934,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3953,13 +3952,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3972,18 +3969,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4086,8 +4080,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4097,7 +4090,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4110,20 +4102,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4140,7 +4129,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4213,8 +4201,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4224,7 +4211,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4300,8 +4286,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4331,7 +4316,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4349,7 +4333,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4388,13 +4371,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "codemirror": "^5.49.0",
     "date-fns": "^2.3.0",
-    "engraved-shared": "0.0.123",
+    "engraved-shared": "file:../shared/dist",
     "markdown-it": "^10.0.0",
     "markdown-it-anchor": "^5.2.4",
     "markdown-it-table-of-contents": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "start": "npm run shared:link && cd server && npm run prod",
     "heroku-postbuild": "npm run shared:link && npm run server:build:prod && npm run client:build:prod",
-    "server:build:prod": "cd server && npm link engraved-shared && npm install && npm install --only=dev --no-shrinkwrap && npm run build",
-    "client:build:prod": "cd client && npm link engraved-shared && npm install && npm install --only=dev --no-shrinkwrap && npm run build && copyfiles -u 1 build/**/*.* ../server/dist/client",
-    "shared:link": "cd shared && npm install && npm install --only=dev --no-shrinkwrap && npm run build && cd dist && npm link && npm install && cd ../../"
+    "server:build:prod": "cd server && npm install && npm install --only=dev --no-shrinkwrap && npm run build",
+    "client:build:prod": "cd client && npm install && npm install --only=dev --no-shrinkwrap && npm run build && copyfiles -u 1 build/**/*.* ../server/dist/client",
+    "shared:link": "cd shared && npm install && npm install --only=dev --no-shrinkwrap && npm run build && cd dist && cd ../../"
   },
   "devDependencies": {
     "copyfiles": "^2.1.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1978,7 +1978,7 @@
       }
     },
     "engraved-shared": {
-      "version": "0.0.123"
+      "version": "file:../shared/dist"
     },
     "error-ex": {
       "version": "1.3.2",
@@ -2571,8 +2571,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2593,14 +2592,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2615,20 +2612,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2745,8 +2739,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2758,7 +2751,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2773,7 +2765,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2781,14 +2772,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2807,7 +2796,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2888,8 +2876,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2901,7 +2888,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2987,8 +2973,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3024,7 +3009,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3044,7 +3028,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3088,14 +3071,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
-    "engraved-shared": "0.0.123",
+    "engraved-shared": "file:../shared/dist",
     "express": "^4.17.1",
     "mongodb": "^3.3.2",
     "passport": "^0.4.0",


### PR DESCRIPTION
Reason: dependabot can obviously not deal with this.
https://github.com/dependabot/dependabot-core/issues/1439

But it also has other advantages, as it makes CI/CD simpler/less steps.